### PR TITLE
iec13818-1.h: fix build with GCC 6.1.0

### DIFF
--- a/iec13818-1.h
+++ b/iec13818-1.h
@@ -42,7 +42,7 @@
 #define BCD(c) ( ((((c) >> 4) & 0x0f) * 10) + ((c) & 0x0f) )
 
 #define TOBYTES( n ) ( ( n + 7 ) / 8 )
-static char bitmask[8] = { 0x01, 0x03, 0x07, 0x0f, 0x1f, 0x3f, 0x7f, 0xff };
+static unsigned char bitmask[8] = { 0x01, 0x03, 0x07, 0x0f, 0x1f, 0x3f, 0x7f, 0xff };
 #define GETBITS( offset, len ) do { \
 	unsigned long value = 0; \
 	while ( len > 0 ) \


### PR DESCRIPTION
Fix the following build issue with GCC 6.1.0:

iec13818-1.h:45:75: error: narrowing conversion of '255' from 'int' to 'char' inside { } [-Wnarrowing]
 static char bitmask[8] = { 0x01, 0x03, 0x07, 0x0f, 0x1f, 0x3f, 0x7f, 0xff };
                                                                                                               ^
