### PR TITLE
Add special case in discoverAVC to recognize Sony DVMC-DA1 as a video source

### DIFF
--- a/raw1394util.c
+++ b/raw1394util.c
@@ -29,6 +29,8 @@
 #include "raw1394util.h"
 
 #define MOTDCT_SPEC_ID    0x00005068
+#define DVMCDA1_VENDOR_ID 0x00080046
+#define DVMCDA1_MODEL_ID  0x00fa0000
 
 
 /** Open the raw1394 device and get a handle.
@@ -150,7 +152,9 @@ int discoverAVC( int* port, octlet_t* guid )
 				}
 				if ( ( ( rom1394_get_node_type( &rom_dir ) == ROM1394_NODE_TYPE_AVC ) &&
 				         avc1394_check_subunit_type( handle, i, AVC1394_SUBUNIT_TYPE_VCR ) ) ||
-				       ( rom_dir.unit_spec_id == MOTDCT_SPEC_ID ) )
+				       ( rom_dir.unit_spec_id == MOTDCT_SPEC_ID ) ||
+				       ( rom_dir.vendor_id == DVMCDA1_VENDOR_ID &&
+				         rom_dir.model_id == DVMCDA1_MODEL_ID ) )
 				{
 					rom1394_free_directory( &rom_dir );
 					octlet_t my_guid, *pguid = ( *guid == 1 )? guid : &my_guid;


### PR DESCRIPTION
The Sony DVMC-DA1 is a media converter without a tape transport. discoverAVC expects video sources to identify as a VCR in response to a SUBUNIT INFO Function Control Protocol command. But the DVMC-DA1 doesn't implement the AV/C command set, so it doesn't respond to the SUBUNIT INFO request at all. As a result, dvgrab doesn't know the device is a video source, so it won't try to use it unless you explicitly point dvgrab at it by GUID.

discoverAVC already has one special case to recognize Motorola DCT set-top boxes. This change adds another special case to also recognize the DVMC-DA1. dvgrab will then use the DVMC-DA1 without requiring a --guid option.

~~Since discoverAVC will potentially discover a non-AV/C device, it also changes the status text from "Found AV/C device" to "Found video device".~~