### PR TITLE
fix: Don't overwrite files in timecode/timestamp/timsys mode

### DIFF
--- a/filehandler.cc
+++ b/filehandler.cc
@@ -440,8 +440,18 @@ bool FileHandler::WriteFrame( Frame *frame )
 			{
 				sb << stimestamp.str();
 			}
+			string baseName = sb.str();
 			sb << GetExtension() << ends;
 			filename = sb.str();
+			struct stat stats;
+			int idx = 0;
+			while( stat( filename.c_str(), &stats ) == 0 )
+			{
+				ostringstream sb2;
+				sb2 << baseName << '_' << setfill( '0' ) << setw( 3 ) << idx++
+					<< GetExtension() << ends;
+				filename = sb2.str();
+			}
 		}
 		else
 		{


### PR DESCRIPTION
- Sometimes subsequently recorded clips are written to the same path, erasing the previously written file.
  - This happens, e.g.  when the `dvgrab` operates in `--timestamp` mode, and some recordings on the camera don't have timestamp information.
- This patch addresses this problem by checking if the output file exists, and if so, the filename is postfixed with a numeric counter.
  - This is similar to the default filename composition logic.