### PR TITLE
Update dvframe.cc

### DIFF
--- a/dvframe.cc
+++ b/dvframe.cc
@@ -422,7 +422,7 @@ bool DVFrame::GetRecordingDate( struct tm &recDate )
 	month = ( month & 0xf ) + 10 * ( ( month >> 4 ) & 0x1 );
 	day = ( day & 0xf ) + 10 * ( ( day >> 4 ) & 0x3 );
 
-	if ( year < 25 )
+	if ( year < 95 )
 		year += 2000;
 	else
 		year += 1900;


### PR DESCRIPTION
**Issue**: all footage captured from 2025 onwards is wrongly displayed as 1925
**Proposed solution**: Edit year check from " year < 25" to "year < 95" to extend the date range from 1925-2024 to 1995-2094 (DV footage before 1995 did not exist)

This issue is also present in all programs/libraries that make use of GetRecordingDate() or libdv's dv_get_recording_datetime_tm():

- dvgrab
- kino 1.3.4
- libdv